### PR TITLE
refactor mixin as factory for sqli classes

### DIFF
--- a/lib/msf/core/exploit/sqli.rb
+++ b/lib/msf/core/exploit/sqli.rb
@@ -4,12 +4,12 @@
 # - implements blind and time-based SQL injection in a reusable manner
 # - Highly extendable (user can run any code to perform the requests, encode payloads and parse results)
 #
+require 'msf/core/exploit/sqli/common'
+require 'msf/core/exploit/sqli/mysqli'
+
 module Msf
   module Exploit::SQLi
-    @@printing_method_names = %i[
-        print_status print_good print_bad print_error print_warning
-        vprint_status vprint_good vprint_bad vprint_error vprint_warning
-    ]
+
     def initialize(info = {})
       super
       register_advanced_options(
@@ -17,33 +17,11 @@ module Msf
           OptFloat.new('SqliDelay', [ false, 'The delay to sleep on time-based blind SQL injections', 1.0 ])
         ]
       )
-      @@datastore = datastore
-      @@framework = framework
-      @@printing_methods = {}
-      @@printing_method_names.each do |sym|
-        @@printing_methods[sym] = method(sym)
-      end
     end
 
-    def self.datastore
-      @@datastore
+    def get_sqli(dbms: , opts: {}, &query_proc)
+      dbms.new(datastore, framework, user_output, opts, &query_proc)
     end
 
-    def self.framework
-      @@framework
-    end
-
-    def self.printing_method_names
-      @@printing_method_names
-    end
-
-    @@printing_method_names.each do |sym|
-      define_singleton_method(sym) do |msg|
-        @@printing_methods[sym].call(msg)
-      end
-    end
   end
 end
-
-require 'msf/core/exploit/sqli/common'
-require 'msf/core/exploit/sqli/mysqli'

--- a/lib/msf/core/exploit/sqli/common.rb
+++ b/lib/msf/core/exploit/sqli/common.rb
@@ -1,5 +1,8 @@
 module Msf::Exploit::SQLi
   class Common
+    autoload :UI, 'msf/core/module/ui'
+    include Msf::Module::UI
+
     #
     #   Creates an instance of an SQL Injection object, instantiate directly only if you don't know the DBMS in use
     #
@@ -17,7 +20,7 @@ module Msf::Exploit::SQLi
     #   `true` if the query returned a result, false otherwise
     #   - if it's a time-based blind SQL injection, the return value does not matter, the time the block takes to run is used to leak information.
     #
-    def initialize(opts={}, &query_proc)
+    def initialize(datastore, framework, user_output, opts={}, &query_proc)
       raise ArgumentError, 'Missing the bloc that does the requests' unless block_given?
 
       check_opts(opts)
@@ -29,15 +32,11 @@ module Msf::Exploit::SQLi
       @truncation_length = opts[:truncation_length] if opts[:truncation_length] && opts[:truncation_length].is_a?(Integer) && opts[:truncation_length] > 0
       @hex_encode_strings = opts[:hex_encode_strings]
       @encoder = opts[:encoder]
-      @datastore = Msf::Exploit::SQLi.datastore
-      @framework = Msf::Exploit::SQLi.framework
+      @datastore = datastore
+      @framework = framework
+      @user_output = user_output
     end
 
-    Msf::Exploit::SQLi.printing_method_names.each do |sym|
-      define_method(sym) do |msg|
-        Msf::Exploit::SQLi.send(sym, msg)
-      end
-    end
     #
     #   Queries the bloc with the given SQL query, and returns the result (this method is used in regular
     #   SQL injection exploits, where the query results are returned in the response to the user)
@@ -53,7 +52,7 @@ module Msf::Exploit::SQLi
       @query_proc.call(query)
     end
 
-    attr_accessor :concat_operator, :second_concat_operator, :null_replacement, :truncation_length, :safe, :datastore, :framework
+    attr_reader :concat_operator, :second_concat_operator, :null_replacement, :truncation_length, :safe, :datastore, :framework
 
     private
 

--- a/lib/msf/core/exploit/sqli/mysqli/boolean_based_blind.rb
+++ b/lib/msf/core/exploit/sqli/mysqli/boolean_based_blind.rb
@@ -2,7 +2,7 @@
 #   Boolean-Based Blind SQL injection support for MySQL
 #
 class Msf::Exploit::SQLi::MySQLi::BooleanBasedBlind < Msf::Exploit::SQLi::MySQLi::Common
-  def initialize(opts={}, &query_proc)
+  def initialize(datastore, framework, user_output, opts={}, &query_proc)
     super
   end
 

--- a/lib/msf/core/exploit/sqli/mysqli/common.rb
+++ b/lib/msf/core/exploit/sqli/mysqli/common.rb
@@ -27,7 +27,7 @@ module Msf::Exploit::SQLi::MySQLi
     #
     #   See SQLi::Common#initialize
     #
-    def initialize(opts={}, &query_proc)
+    def initialize(datastore, framework, user_output, opts={}, &query_proc)
       if opts[:encoder].is_a?(String) || opts[:encoder].is_a?(Symbol)
         # if it's a String or a Symbol, use a predefined encoder if it exists
         opts[:encoder] = opts[:encoder].downcase.intern

--- a/lib/msf/core/exploit/sqli/mysqli/time_based_blind.rb
+++ b/lib/msf/core/exploit/sqli/mysqli/time_based_blind.rb
@@ -2,7 +2,7 @@
 #   Time-Based Blind SQL injection support for MySQL
 #
 class Msf::Exploit::SQLi::MySQLi::TimeBasedBlind < Msf::Exploit::SQLi::MySQLi::Common
-  def initialize(opts={}, &query_proc)
+  def initialize(datastore, framework, user_output, opts={}, &query_proc)
     super
   end
 

--- a/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
+++ b/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Auxiliary
       encoder: :base64, # the web application messes up multibyte characters, better encode
       verbose: datastore['VERBOSE']
     }
-    sqli = MySQLi::Common.new(sqli_opts) do |payload|
+    sqli = get_sqli(dbms: MySQLi::Common, opts: sqli_opts) do |payload|
       res = get_response(payload)
       if res && (response = res.body[%r{XPATH syntax error: '~(.*?)'</font>}m, 1])
         response

--- a/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
+++ b/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
@@ -165,7 +165,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def sqli_to_admin_session
-    @sqli = MySQLi::TimeBasedBlind.new do |payload|
+    @sqli = get_sqli(dbms: MySQLi::TimeBasedBlind) do |payload|
       res = send_request_cgi({
         'method' => 'GET',
         'uri' => normalize_uri(target_uri.path, '/login.php'),


### PR DESCRIPTION
Remove class level injections in favor of a factory that injects objects and creates instances for the module writer.